### PR TITLE
fixed a bug with passing --max-timeout argument

### DIFF
--- a/grey_harvest.py
+++ b/grey_harvest.py
@@ -216,7 +216,6 @@ def setup(parser):
     )
     parser.add_argument('-t', '--max-timeout', 
                     dest='max_timeout',
-                    nargs=1,
                     type=int,
                     metavar='<N>',
                     default=MAX_TIMEOUT,


### PR DESCRIPTION
Running
```
$ grey_harvest -n 100 -H -D example.com -t 1
```

Would lead to an exception:
```
Traceback (most recent call last):
  File "/.venv/testingenv/bin/grey_harvest", line 9, in <module>
    load_entry_point('grey-harvest==0.1.5', 'console_scripts', 'grey_harvest')()
  File "/.venv/testingenv/lib/python2.7/site-packages/grey_harvest.py", line 280, in main
    for proxy in harvester.run():
  File "/.venv/testingenv/lib/python2.7/site-packages/grey_harvest.py", line 108, in run
    max_timeout = self.max_timeout,
  File "/.venv/testingenv/lib/python2.7/site-packages/grey_harvest.py", line 67, in test
    requests.head(test_url, timeout=max_timeout, proxies=proxies)
  File "/.venv/testingenv/lib/python2.7/site-packages/requests/api.py", line 101, in head
    return request('head', url, **kwargs)
  File "/.venv/testingenv/lib/python2.7/site-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "/.venv/testingenv/lib/python2.7/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/.venv/testingenv/lib/python2.7/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/.venv/testingenv/lib/python2.7/site-packages/requests/adapters.py", line 435, in send
    timeout = TimeoutSauce(connect=timeout, read=timeout)
  File "/.venv/testingenv/lib/python2.7/site-packages/urllib3/util/timeout.py", line 94, in __init__
    self._connect = self._validate_timeout(connect, 'connect')
  File "/.venv/testingenv/lib/python2.7/site-packages/urllib3/util/timeout.py", line 127, in _validate_timeout
    "int, float or None." % (name, value))
ValueError: Timeout value connect was [1], but it must be an int, float or None.
```

This happened because `-t` or `--max-timeout` was passed as an array from CLI, but should be passed as an int.

This PR fixes it.